### PR TITLE
fix: Add language hint for Endo archive generator

### DIFF
--- a/contract/package.json
+++ b/contract/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "description": "OTC Desk contract",
+  "parsers": {"js": "mjs"},
   "scripts": {
     "build": "exit 0",
     "test": "ava --verbose",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "contract",
     "_agstate/agoric-servers"
   ],
+  "parsers": {"js": "mjs"},
   "devDependencies": {
     "eslint": "^7.23.0",
     "eslint-config-airbnb": "^18.0.1",


### PR DESCRIPTION
This adds a prsers declaration to package.json, which Endo's compartment mapper recognizes that a `.js` file is a JavaScript module and not a CommonJS module, but unlike `"type": "module"`, does not confuse `node -r esm`.
