### PR TITLE
fix: fix bundle compare tests

### DIFF
--- a/contract/test/test-coveredCall.js
+++ b/contract/test/test-coveredCall.js
@@ -38,7 +38,7 @@ test('contract with valid offers', async t => {
 
   const coveredCallInstallation = await E(zoe).install(coveredCallBundle);
 
-  t.is(await E(coveredCallInstallation).getBundle(), coveredCallBundle);
+  t.deepEqual(await E(coveredCallInstallation).getBundle(), coveredCallBundle);
 
   // Create a magical item NFT mint
   const magicItemKit = makeIssuerKit('magicItem', AssetKind.SET);

--- a/contract/test/test-otcDesk.js
+++ b/contract/test/test-otcDesk.js
@@ -37,11 +37,11 @@ test('contract with valid offers', async t => {
   const coveredCallPath = url.fileURLToPath(coveredCallUrl);
   const coveredCallBundle = await bundleSource(coveredCallPath);
   const coveredCallInstallation = await E(zoe).install(coveredCallBundle);
-  t.is(await E(coveredCallInstallation).getBundle(), coveredCallBundle);
+  t.deepEqual(await E(coveredCallInstallation).getBundle(), coveredCallBundle);
 
   const otcDeskBundle = await bundleSource(otcDeskPath);
   const otcDeskInstallation = await E(zoe).install(otcDeskBundle);
-  t.is(await E(otcDeskInstallation).getBundle(), otcDeskBundle);
+  t.deepEqual(await E(otcDeskInstallation).getBundle(), otcDeskBundle);
 
   // Create a magical item NFT mint
   const magicItemKit = makeIssuerKit('magicItem', AssetKind.SET);


### PR DESCRIPTION
These tests were using `is` incorrectly, but it happened to work. They should always have used `deepEqual` or similar, that does a structural comparison. Noticed by CI failing on https://github.com/Agoric/agoric-sdk/pull/5283

Separately, storing bundles is not recommended, since they are huge. This is why we've shifted to bundleIDs. But this PR does not make that change.