### PR TITLE
fix: creator facet needs to be Far

### DIFF
--- a/contract/src/otcDesk.js
+++ b/contract/src/otcDesk.js
@@ -6,7 +6,7 @@ import {
   withdrawFromSeat,
   depositToSeat,
 } from '@agoric/zoe/src/contractSupport/index.js';
-import { E } from '@endo/far';
+import { E, Far } from '@endo/far';
 
 /**
  
@@ -18,7 +18,7 @@ const start = async zcf => {
   const { zcfSeat: marketMakerSeat } = zcf.makeEmptySeatKit();
   const zoe = zcf.getZoeService();
 
-  const creatorFacet = {
+  const creatorFacet = Far('creator', {
     makeAddInventoryInvitation: async issuerKeywordRecord => {
       await saveAllIssuers(zcf, issuerKeywordRecord);
       /** @type OfferHandler */
@@ -75,7 +75,7 @@ const start = async zcf => {
       const option = E(sellUserSeat).getOfferResult();
       return option;
     },
-  };
+  });
   return harden({ creatorFacet });
 };
 


### PR DESCRIPTION
Now that ZCF requires creator facets to be durable, we must build it
with Far() instead of a bare object literal.

closes #39