### PR TITLE
feat: integrate with changes for Zoe Durability

### DIFF
--- a/contract/test/test-coveredCall.js
+++ b/contract/test/test-coveredCall.js
@@ -17,7 +17,7 @@ test('contract with valid offers', async t => {
   // Outside of tests, we should use the long-lived Zoe on the
   // testnet. In this test, we must create a new Zoe.
   const { zoeService } = makeZoeKit(makeFakeVatAdmin().admin);
-  const feePurse = E(zoeService).makeFeePurse();
+  const feePurse = E(E(zoeService).getFeeIssuer()).makeEmptyPurse();
   const zoe = E(zoeService).bindDefaultFeePurse(feePurse);
 
   // Alice is going to want to trade a magical wand item for some fake


### PR DESCRIPTION
This change is backwards compatible (makeFeePurse was deprecated), so it doesn't have to wait for [5997](https://github.com/Agoric/agoric-sdk/pull/5997) to land.